### PR TITLE
Disable filter use for retrieving active help requests

### DIFF
--- a/src/main/java/com/uu/au/controllers/HelpRequestController.java
+++ b/src/main/java/com/uu/au/controllers/HelpRequestController.java
@@ -83,7 +83,8 @@ class HelpRequestController {
     @CrossOrigin
     @GetMapping("/helpRequests/active")
     List<HelpRequest> active() {
-        return SquigglyUtils.listify(Squiggly.init(AUPortal.OBJECT_MAPPER, HelpRequestController.filterStudent), pending(), HelpRequest.class);
+        return pending();
+        //return SquigglyUtils.listify(Squiggly.init(AUPortal.OBJECT_MAPPER, HelpRequestController.filterStudent), pending(), HelpRequest.class);
     }
 
     List<HelpRequest> pending() {

--- a/src/main/java/com/uu/au/controllers/HelpRequestController.java
+++ b/src/main/java/com/uu/au/controllers/HelpRequestController.java
@@ -59,7 +59,7 @@ class HelpRequestController {
 
     private final Logger logger = LoggerFactory.getLogger(UserController.class);
 
-    public static final String filterStudent = "**,submitters[id,firstName,lastName,verifiedProfilePic],helper[id,firstName,lastName]";
+    public static final String filterStudent = "**,submitters[id,firstName,lastName,verifiedProfilePic,needsProfilePic],helper[id,firstName,lastName]";
 
     public List<HelpRequest> helpRequestsCurrentCourseInstance() {
         var currentCourseStartDate = courses.currentCourseInstance().getStartDate().atStartOfDay();


### PR DESCRIPTION
The filter used on pending help requests should be disabled because it does not compute correct values for certain boolean values of users (`needsProfilePic` for example). This PR disables the filter and return unfiltered pending requests instead, which is very much similar to what was done in commit https://github.com/bubify/bubify-backend/commit/00166c0acc0ebf1aa9940eb2a9e46e2028793c68 to prevent wrong values being used.

With this change, the correct value for `needsProfilePic` (among others) is computed correctly and can be used in the client to determine whether to render a profile picture in certain scenarios for example.

Specifically for `needsProfilePic` I've also added it to the filter in case it is added back in the future.