### PR TITLE
Remove unused method User.emailAddress()

### DIFF
--- a/src/main/java/com/uu/au/models/User.java
+++ b/src/main/java/com/uu/au/models/User.java
@@ -117,12 +117,6 @@ public class User {
         return role.equals(Role.TEACHER) || role.equals(Role.SENIOR_TA);
     }
 
-    public String emailAddress() {
-        return isPriviliged()
-                ? firstName + "." + lastName + "@it.uu.se"
-                : firstName + "." + lastName + "." + userName.substring(4) + "@student.uu.se";
-    }
-
     @JsonIgnore
     public Optional<Enrolment> lastEnrolment() {
         if (enrolments == null) return Optional.empty();


### PR DESCRIPTION
The method in itself was possibly problematic as not all student emails follow the presumed format.